### PR TITLE
Optimize VRAM Usage. Works on 16G 4060ti now!

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ conda activate mimicmotion
 ```
 
 ### Download weights
+If you experience connection issues with Hugging Face, you can utilize the mirror endpoint by setting the environment variable: `export HF_ENDPOINT=https://hf-mirror.com`.
 Please download weights manually as follows:
 ```
 cd MimicMotions/
@@ -56,8 +57,8 @@ mkdir models
 1. Download DWPose pretrained model: [dwpose](https://huggingface.co/yzd-v/DWPose/tree/main)
     ```
     mkdir -p models/DWPose
-    wget https://hf-mirror.com/yzd-v/DWPose/resolve/main/yolox_l.onnx?download=true -O models/DWPose/yolox_l.onnx
-    wget https://hf-mirror.com/yzd-v/DWPose/resolve/main/dw-ll_ucoco_384.onnx?download=true -O models/DWPose/dw-ll_ucoco_384.onnx
+    wget https://huggingface.co/yzd-v/DWPose/resolve/main/yolox_l.onnx?download=true -O models/DWPose/yolox_l.onnx
+    wget https://huggingface.co/yzd-v/DWPose/resolve/main/dw-ll_ucoco_384.onnx?download=true -O models/DWPose/dw-ll_ucoco_384.onnx
     ```
 2. Download the pre-trained checkpoint of MimicMotion from [Huggingface](https://huggingface.co/ixaac/MimicMotion)
     ```
@@ -84,6 +85,12 @@ python inference.py --inference_config configs/test.yaml
 ```
 
 Tips: if your GPU memory is limited, try set env `PYTORCH_CUDA_ALLOC_CONF=max_split_size_mb:256`.
+
+### VRAM requirement and Runtime
+
+For the 35s demo video, the 72-frame model requires 16GB VRAM (4060ti) and finishes in 20 minutes on a 4090 GPU.
+
+The minimum VRAM requirement for the 16-frame U-Net model is 8GB; however, the VAE decoder demands 16GB. You have the option to run the VAE decoder on CPU.
 
 ## Citation	
 ```bib

--- a/README.md
+++ b/README.md
@@ -53,23 +53,17 @@ Please download weights manually as follows:
 cd MimicMotions/
 mkdir models
 ```
-1. Download SVD model: [stabilityai/stable-video-diffusion-img2vid-xt-1-1](https://huggingface.co/stabilityai/stable-video-diffusion-img2vid-xt-1-1)
+1. Download DWPose pretrained model: [dwpose](https://huggingface.co/yzd-v/DWPose/tree/main)
     ```
-    git lfs install
-    git clone https://huggingface.co/stabilityai/stable-video-diffusion-img2vid-xt-1-1
-    mkdir -p models/SVD
-    mv stable-video-diffusion-img2vid-xt-1-1 models/SVD/
+    mkdir -p models/DWPose
+    wget https://hf-mirror.com/yzd-v/DWPose/resolve/main/yolox_l.onnx?download=true -O models/DWPose/yolox_l.onnx
+    wget https://hf-mirror.com/yzd-v/DWPose/resolve/main/dw-ll_ucoco_384.onnx?download=true -O models/DWPose/dw-ll_ucoco_384.onnx
     ```
-2. Download DWPose pretrained model: [dwpose](https://huggingface.co/yzd-v/DWPose/tree/main)
-    ```
-    git lfs install
-    git clone https://huggingface.co/yzd-v/DWPose
-    mv DWPose models/
-    ```
-3. Download the pre-trained checkpoint of MimicMotion from [Huggingface](https://huggingface.co/ixaac/MimicMotion)
+2. Download the pre-trained checkpoint of MimicMotion from [Huggingface](https://huggingface.co/ixaac/MimicMotion)
     ```
     wget -P models/ https://huggingface.co/ixaac/MimicMotion/resolve/main/MimicMotion_1-1.pth
     ```
+3. The SVD model [stabilityai/stable-video-diffusion-img2vid-xt-1-1](https://huggingface.co/stabilityai/stable-video-diffusion-img2vid-xt-1-1) will be automatically downloaded.
 
 Finally, all the weights should be organized in models as follows
 
@@ -78,8 +72,6 @@ models/
 ├── DWPose
 │   ├── dw-ll_ucoco_384.onnx
 │   └── yolox_l.onnx
-├── SVD
-│   └──stable-video-diffusion-img2vid-xt-1-1
 └── MimicMotion_1-1.pth
 ```
 
@@ -90,6 +82,8 @@ A sample configuration for testing is provided as `test.yaml`. You can also easi
 ```
 python inference.py --inference_config configs/test.yaml
 ```
+
+Tips: if your GPU memory is limited, try set env `PYTORCH_CUDA_ALLOC_CONF=max_split_size_mb:256`.
 
 ## Citation	
 ```bib

--- a/configs/test.yaml
+++ b/configs/test.yaml
@@ -1,5 +1,5 @@
 # base svd model path
-base_model_path: models/SVD/stable-video-diffusion-img2vid-xt-1-1
+base_model_path: stabilityai/stable-video-diffusion-img2vid-xt-1-1
 
 # checkpoint path
 ckpt_path: models/MimicMotion_1-1.pth

--- a/inference.py
+++ b/inference.py
@@ -13,6 +13,9 @@ from torchvision.transforms.functional import pil_to_tensor, resize, center_crop
 from torchvision.transforms.functional import to_pil_image
 
 
+from mimicmotion.utils.geglu_patch import patch_geglu_inplace
+patch_geglu_inplace()
+
 from constants import ASPECT_RATIO
 
 from mimicmotion.pipelines.pipeline_mimicmotion import MimicMotionPipeline

--- a/inference.py
+++ b/inference.py
@@ -63,11 +63,10 @@ def preprocess(video_path, image_path, resolution=576, sample_stride=2):
 
 def run_pipeline(pipeline: MimicMotionPipeline, image_pixels, pose_pixels, device, task_config):
     image_pixels = [to_pil_image(img.to(torch.uint8)) for img in (image_pixels + 1.0) * 127.5]
-    pose_pixels = pose_pixels.unsqueeze(0).to(device)
     generator = torch.Generator(device=device)
     generator.manual_seed(task_config.seed)
     frames = pipeline(
-        image_pixels, image_pose=pose_pixels, num_frames=pose_pixels.size(1),
+        image_pixels, image_pose=pose_pixels, num_frames=pose_pixels.size(0),
         tile_size=task_config.num_frames, tile_overlap=task_config.frames_overlap,
         height=pose_pixels.shape[-2], width=pose_pixels.shape[-1], fps=7,
         noise_aug_strength=task_config.noise_aug_strength, num_inference_steps=task_config.num_inference_steps,

--- a/mimicmotion/dwpose/dwpose_detector.py
+++ b/mimicmotion/dwpose/dwpose_detector.py
@@ -20,9 +20,17 @@ class DWposeDetector:
         device: (str) 'cpu' or 'cuda:{device_id}'
     """
     def __init__(self, model_det, model_pose, device='cpu'):
-        self.pose_estimation = Wholebody(model_det=model_det, model_pose=model_pose, device=device)
+        self.args = model_det, model_pose, device
+
+    def release_memory(self):
+        if hasattr(self, 'pose_estimation'):
+            del self.pose_estimation
+            import gc; gc.collect()
 
     def __call__(self, oriImg):
+        if not hasattr(self, 'pose_estimation'):
+            self.pose_estimation = Wholebody(*self.args)
+
         oriImg = oriImg.copy()
         H, W, C = oriImg.shape
         with torch.no_grad():

--- a/mimicmotion/dwpose/preprocess.py
+++ b/mimicmotion/dwpose/preprocess.py
@@ -1,3 +1,4 @@
+from tqdm import tqdm
 import decord
 import numpy as np
 
@@ -32,7 +33,9 @@ def get_video_pose(
     vr = decord.VideoReader(video_path, ctx=decord.cpu(0))
     sample_stride *= max(1, int(vr.get_avg_fps() / 24))
 
-    detected_poses = [dwprocessor(frm) for frm in vr.get_batch(list(range(0, len(vr), sample_stride))).asnumpy()]
+    frames = vr.get_batch(list(range(0, len(vr), sample_stride))).asnumpy()
+    detected_poses = [dwprocessor(frm) for frm in tqdm(frames, desc="DWPose")]
+    dwprocessor.release_memory()
 
     detected_bodies = np.stack(
         [p['bodies']['candidate'] for p in detected_poses if p['bodies']['candidate'].shape[0] == 18])[:,

--- a/mimicmotion/pipelines/pipeline_mimicmotion.py
+++ b/mimicmotion/pipelines/pipeline_mimicmotion.py
@@ -161,24 +161,6 @@ class MimicMotionPipeline(DiffusionPipeline):
 
         return image_embeddings
 
-    def _encode_pose_image(
-        self, 
-        pose_image: torch.Tensor, 
-        do_classifier_free_guidance: bool,
-    ):
-        # Get latents_pose
-        pose_latents = self.pose_net(pose_image)
-
-        if do_classifier_free_guidance:
-            negative_pose_latents = torch.zeros_like(pose_latents)
-
-            # For classifier free guidance, we need to do two forward passes.
-            # Here we concatenate the unconditional and text embeddings into a single batch
-            # to avoid doing two forward passes
-            pose_latents = torch.cat([negative_pose_latents, pose_latents])
-
-        return pose_latents
-
     def _encode_vae_image(
         self,
         image: torch.Tensor,
@@ -186,7 +168,7 @@ class MimicMotionPipeline(DiffusionPipeline):
         num_videos_per_prompt: int,
         do_classifier_free_guidance: bool,
     ):
-        image = image.to(device=device)
+        image = image.to(device=device, dtype=self.vae.dtype)
         image_latents = self.vae.encode(image).latent_dist.mode()
 
         if do_classifier_free_guidance:
@@ -322,9 +304,8 @@ class MimicMotionPipeline(DiffusionPipeline):
     # corresponds to doing no classifier free guidance.
     @property
     def do_classifier_free_guidance(self):
-        return True # TODO
         if isinstance(self.guidance_scale, (int, float)):
-            return self.guidance_scale
+            return self.guidance_scale > 1
         return self.guidance_scale.max() > 1
 
     @property
@@ -369,7 +350,6 @@ class MimicMotionPipeline(DiffusionPipeline):
         num_videos_per_prompt: Optional[int] = 1,
         generator: Optional[Union[torch.Generator, List[torch.Generator]]] = None,
         latents: Optional[torch.FloatTensor] = None,
-        first_n_frames=None,
         output_type: Optional[str] = "pil",
         callback_on_step_end: Optional[Callable[[int, int, Dict], None]] = None,
         callback_on_step_end_tensor_inputs: List[str] = ["latents"],
@@ -488,7 +468,9 @@ class MimicMotionPipeline(DiffusionPipeline):
         self._guidance_scale = max_guidance_scale
 
         # 3. Encode input image
+        self.image_encoder.to(device)
         image_embeddings = self._encode_image(image, device, num_videos_per_prompt, self.do_classifier_free_guidance)
+        self.image_encoder.cpu()
 
         # NOTE: Stable Diffusion Video was conditioned on fps - 1, which
         # is why it is reduced here.
@@ -499,10 +481,7 @@ class MimicMotionPipeline(DiffusionPipeline):
         noise = randn_tensor(image.shape, generator=generator, device=device, dtype=image.dtype)
         image = image + noise_aug_strength * noise
 
-        needs_upcasting = self.vae.dtype == torch.float16 and self.vae.config.force_upcast
-        if needs_upcasting:
-            self.vae.to(dtype=torch.float32)
-
+        self.vae.to(device)
         image_latents = self._encode_vae_image(
             image,
             device=device,
@@ -510,15 +489,7 @@ class MimicMotionPipeline(DiffusionPipeline):
             do_classifier_free_guidance=self.do_classifier_free_guidance,
         )
         image_latents = image_latents.to(image_embeddings.dtype)
-
-        ref_latent = first_n_frames[:, 0] if first_n_frames is not None else None
-        pose_latents = self._encode_pose_image(
-            image_pose, do_classifier_free_guidance=self.do_classifier_free_guidance,
-        )
-
-        # cast back to fp16 if needed
-        if needs_upcasting:
-            self.vae.to(dtype=torch.float16)
+        self.vae.cpu()
 
         # Repeat the image latents for each frame so we can concatenate them with the noise
         # image_latents [batch, channels, height, width] ->[batch, num_frames, channels, height, width]
@@ -567,11 +538,16 @@ class MimicMotionPipeline(DiffusionPipeline):
 
         # 8. Denoising loop
         self._num_timesteps = len(timesteps)
-        pose_latents = einops.rearrange(pose_latents, '(b f) c h w -> b f c h w', f=num_frames)
         indices = [[0, *range(i + 1, min(i + tile_size, num_frames))] for i in
                    range(0, num_frames - tile_size + 1, tile_size - tile_overlap)]
         if indices[-1][-1] < num_frames - 1:
             indices.append([0, *range(num_frames - tile_size + 1, num_frames)])
+
+        self.pose_net.to(device)
+        self.unet.to(device)
+
+        with torch.cuda.device(device):
+            torch.cuda.empty_cache()
 
         with self.progress_bar(total=len(timesteps) * len(indices)) as progress_bar:
             for i, t in enumerate(timesteps):
@@ -585,20 +561,35 @@ class MimicMotionPipeline(DiffusionPipeline):
                 # predict the noise residual
                 noise_pred = torch.zeros_like(image_latents)
                 noise_pred_cnt = image_latents.new_zeros((num_frames,))
-                # image_pose = pixel_values_pose[:, frame_start:frame_start + self.num_frames, ...]
                 weight = (torch.arange(tile_size, device=device) + 0.5) * 2. / tile_size
                 weight = torch.minimum(weight, 2 - weight)
                 for idx in indices:
+
+                    # classification-free inference
+                    pose_latents = self.pose_net(image_pose[idx].to(device))
                     _noise_pred = self.unet(
-                        latent_model_input[:, idx],
+                        latent_model_input[:1, idx],
                         t,
-                        encoder_hidden_states=image_embeddings,
-                        added_time_ids=added_time_ids,
-                        pose_latents=pose_latents[:, idx].flatten(0, 1),
+                        encoder_hidden_states=image_embeddings[:1],
+                        added_time_ids=added_time_ids[:1],
+                        pose_latents=None,
                         image_only_indicator=image_only_indicator,
                         return_dict=False,
                     )[0]
-                    noise_pred[:, idx] += _noise_pred * weight[:, None, None, None]
+                    noise_pred[:1, idx] += _noise_pred * weight[:, None, None, None]
+
+                    # normal inference
+                    _noise_pred = self.unet(
+                        latent_model_input[1:, idx],
+                        t,
+                        encoder_hidden_states=image_embeddings[1:],
+                        added_time_ids=added_time_ids[1:],
+                        pose_latents=pose_latents,
+                        image_only_indicator=image_only_indicator,
+                        return_dict=False,
+                    )[0]
+                    noise_pred[1:, idx] += _noise_pred * weight[:, None, None, None]
+
                     noise_pred_cnt[idx] += weight
                     progress_bar.update()
                 noise_pred.div_(noise_pred_cnt[:, None, None, None])
@@ -607,12 +598,6 @@ class MimicMotionPipeline(DiffusionPipeline):
                 if self.do_classifier_free_guidance:
                     noise_pred_uncond, noise_pred_cond = noise_pred.chunk(2)
                     noise_pred = noise_pred_uncond + self.guidance_scale * (noise_pred_cond - noise_pred_uncond)
-
-                if first_n_frames is not None:
-                    sigma = self.scheduler.sigmas[self.scheduler.step_index]
-                    _latents = latents[:, 1:1 + first_n_frames.size(1)]
-                    tmp = (first_n_frames - _latents / (sigma ** 2 + 1)) / (-sigma / ((sigma ** 2 + 1) ** 0.5))
-                    noise_pred[:, 1:1 + first_n_frames.size(1)] = tmp
 
                 # compute the previous noisy sample x_t -> x_t-1
                 latents = self.scheduler.step(noise_pred, t, latents, **extra_step_kwargs, return_dict=False)[0]
@@ -625,10 +610,11 @@ class MimicMotionPipeline(DiffusionPipeline):
 
                     latents = callback_outputs.pop("latents", latents)
 
+        self.pose_net.cpu()
+        self.unet.cpu()
+
         if not output_type == "latent":
-            # cast back to fp16 if needed
-            if needs_upcasting:
-                self.vae.to(dtype=torch.float16)
+            self.vae.decoder.to(device)
             frames = self.decode_latents(latents, num_frames, decode_chunk_size)
             frames = tensor2vid(frames, self.image_processor, output_type=output_type)
         else:

--- a/mimicmotion/utils/geglu_patch.py
+++ b/mimicmotion/utils/geglu_patch.py
@@ -1,0 +1,9 @@
+import diffusers.models.activations
+
+
+def patch_geglu_inplace():
+    """Patch GEGLU with inplace multiplication to save GPU memory."""
+    def forward(self, hidden_states):
+        hidden_states, gate = self.proj(hidden_states).chunk(2, dim=-1)
+        return hidden_states.mul_(self.gelu(gate))
+    diffusers.models.activations.GEGLU.forward = forward

--- a/mimicmotion/utils/loader.py
+++ b/mimicmotion/utils/loader.py
@@ -22,9 +22,9 @@ class MimicMotionModel(torch.nn.Module):
         self.unet = UNetSpatioTemporalConditionModel.from_config(
             UNetSpatioTemporalConditionModel.load_config(base_model_path, subfolder="unet"))
         self.vae = AutoencoderKLTemporalDecoder.from_pretrained(
-            base_model_path, subfolder="vae").half()
+            base_model_path, subfolder="vae", torch_dtype=torch.float16, variant="fp16")
         self.image_encoder = CLIPVisionModelWithProjection.from_pretrained(
-            base_model_path, subfolder="image_encoder")
+            base_model_path, subfolder="image_encoder", torch_dtype=torch.float16, variant="fp16")
         self.noise_scheduler = EulerDiscreteScheduler.from_pretrained(
             base_model_path, subfolder="scheduler")
         self.feature_extractor = CLIPImageProcessor.from_pretrained(
@@ -39,8 +39,8 @@ def create_pipeline(infer_config, device):
         infer_config (str): 
         device (str or torch.device): "cpu" or "cuda:{device_id}"
     """
-    mimicmotion_models = MimicMotionModel(infer_config.base_model_path).to(device=device).eval()
-    mimicmotion_models.load_state_dict(torch.load(infer_config.ckpt_path, map_location=device), strict=False)
+    mimicmotion_models = MimicMotionModel(infer_config.base_model_path)
+    mimicmotion_models.load_state_dict(torch.load(infer_config.ckpt_path, map_location="cpu"), strict=False)
     pipeline = MimicMotionPipeline(
         vae=mimicmotion_models.vae, 
         image_encoder=mimicmotion_models.image_encoder, 


### PR DESCRIPTION
This pull request implements:
- Execute CFG in separate batches https://github.com/Tencent/MimicMotion/issues/21#issuecomment-2213978415
- Offload unused modules https://github.com/Tencent/MimicMotion/issues/21#issuecomment-2216287573

The pipeline requires only _16G_ VRAM (tested on 4060ti) and finishes in _20 minutes_ on a 4090 GPU for the 35s demo using our 72-frame model. This information answers https://github.com/Tencent/MimicMotion/issues/17 and is added to the Readme. This fix should also resolve the runtime issue in https://github.com/Tencent/MimicMotion/issues/27 caused by VRAM spilling into slow CPU memory.

Minor change: Avoid downloading the entire SVD-1.1 repository; instead, download only the necessary files during execution.