### PR TITLE
Force huggingface_hub version to prevent breaking change

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -10,6 +10,7 @@ dependencies:
   - pip
   - pip:
     - diffusers==0.27.0
+    - huggingface_hub==0.25.2
     - transformers==4.32.1
     - decord==0.6.0
     - einops


### PR DESCRIPTION
On 10/17/24, hugging face released [version v0.26.0 of huggingface_hub](https://github.com/huggingface/huggingface_hub/releases/tag/v0.26.0) which introduced the following breaking changes:


![Screenshot 2024-10-18 at 9 47 36 PM](https://github.com/user-attachments/assets/c9caba63-2a71-49e2-82d8-6b137ce73b4e)

This creates a stacktrace because `diffusers` pulls the latest version of `huggingface_hub ` [as seen here](https://github.com/huggingface/diffusers/blob/main/setup.py#L104).

Full stack trace:
```
$ python inference.py --inference_config configs/test.yaml
Traceback (most recent call last):
  File "MimicMotion/inference.py", line 16, in <module>
    from mimicmotion.utils.geglu_patch import patch_geglu_inplace
  File "MimicMotion/mimicmotion/utils/geglu_patch.py", line 1, in <module>
    import diffusers.models.activations
  File "MimicMotion/venv/lib/python3.11/site-packages/diffusers/__init__.py", line 5, in <module>
    from .utils import (
  File "MimicMotion/venv/lib/python3.11/site-packages/diffusers/utils/__init__.py", line 38, in <module>
    from .dynamic_modules_utils import get_class_from_dynamic_module
  File "MimicMotion/venv/lib/python3.11/site-packages/diffusers/utils/dynamic_modules_utils.py", line 28, in <module>
    from huggingface_hub import cached_download, hf_hub_download, model_info
ImportError: cannot import name 'cached_download' from 'huggingface_hub' (MimicMotion/venv/lib/python3.11/site-packages/huggingface_hub/__init__.py)
```

This pull requests forces the version 0.25.2 of `huggingface_hub` which resolves the stacktrace.