### PR TITLE
Commented out automatic sample_stride adjustment based on FPS

### DIFF
--- a/mimicmotion/dwpose/preprocess.py
+++ b/mimicmotion/dwpose/preprocess.py
@@ -31,7 +31,7 @@ def get_video_pose(
 
     # read input video
     vr = decord.VideoReader(video_path, ctx=decord.cpu(0))
-    sample_stride *= max(1, int(vr.get_avg_fps() / 24))
+    # sample_stride *= max(1, int(vr.get_avg_fps() / 24))
 
     frames = vr.get_batch(list(range(0, len(vr), sample_stride))).asnumpy()
     detected_poses = [dwprocessor(frm) for frm in tqdm(frames, desc="DWPose")]


### PR DESCRIPTION
This commit removes the line:
sample_stride *= max(1, int(vr.get_avg_fps() / 24)) Rationale:
- This adjustment overrides the user-specified sample_stride in config
- When sample_stride is set to 1, this adjustment can cause program failures
- Example failure case: With num_frames=64 and stride=1, adjustment doubles stride to 2
- This halves the processed frames from 64 to 32, causing DWPose to only process half the frames
- Subsequently causes empty indices list generation since tile_size=64 > num_frames=33
- Empty indices occur in: [[0, *range(i + 1, min(i + tile_size, num_frames))] for i in range(0, num_frames - tile_size + 1, tile_size - tile_overlap)] This change preserves user config settings and prevents downstream processing errors.